### PR TITLE
GitHub Action to lint Python code for syntax errors

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,5 +1,5 @@
 name: lint_python
-on: [pull_request, push:]
+on: [pull_request, push]
 jobs:
   lint_python:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,20 @@
+name: lint_python
+on: [pull_request, push:]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install black codespell flake8 isort pytest
+      - run: black --check . || true
+      # - run: black --diff . || true
+      # - if: matrix.python-version >= 3.6
+      #  run: |
+      #    pip install black
+      #    black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/Python/Projects/Cartooning an image (python)/cartooneffect.py
+++ b/Python/Projects/Cartooning an image (python)/cartooneffect.py
@@ -1,3 +1,5 @@
+import cv2
+
 
 class Cartoonizer: 
 	"""Cartoonizer effect 

--- a/Python/Projects/Cartooning an image (python)/cartooneffect.py
+++ b/Python/Projects/Cartooning an image (python)/cartooneffect.py
@@ -20,20 +20,20 @@ class Cartoonizer:
 
 		# downsample image using Gaussian pyramid 
 		img_color = img_rgb 
-		for _ in xrange(numDownSamples): 
+		for _ in range(numDownSamples): 
 			img_color = cv2.pyrDown(img_color) 
 
 		#cv2.imshow("downcolor",img_color) 
 		#cv2.waitKey(0) 
 		# repeatedly apply small bilateral filter instead of applying 
 		# one large filter 
-		for _ in xrange(numBilateralFilters): 
+		for _ in range(numBilateralFilters): 
 			img_color = cv2.bilateralFilter(img_color, 9, 9, 7) 
 
 		#cv2.imshow("bilateral filter",img_color) 
 		#cv2.waitKey(0) 
 		# upsample image to original size 
-		for _ in xrange(numDownSamples): 
+		for _ in range(numDownSamples): 
 			img_color = cv2.pyrUp(img_color) 
 		#cv2.imshow("upscaling",img_color) 
 		#cv2.waitKey(0) 

--- a/Python/word_order.py
+++ b/Python/word_order.py
@@ -41,3 +41,4 @@ if __name__ == '__main__':
             l[s]=1
 print(len(l))
 for e in l.keys():
+    print(e)


### PR DESCRIPTION
Output: https://github.com/cclauss/-HACKTOBERFEST2K20/actions 

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.